### PR TITLE
learn-how-setup-variables-from-JVM-system-properties-and-from-vm-options

### DIFF
--- a/Jar File/How Create a Jar file
+++ b/Jar File/How Create a Jar file
@@ -11,7 +11,12 @@ java -jar  target/configdemo-0.0.1-SNAPSHOT.jar
 ---------------------------------------------------------------------------------------------------------------
 
 This is how we can pass environment from JVM System Properties via running a jar file
+This is for git bash
+
 java -Dbuild.id=9999 -Dbuild.name=9Build -Dbuild.version=1.0.1 -jar target/configdemo-0.0.1-SNAPSHOT.jar
+
+This is the way to execute this on command prompt use -- instead of -D
+java --build.id=9999 --build.name=9Build --build.version=1.0.1 -jar target/configdemo-0.0.1-SNAPSHOT.jar
 
 -----------------------------------------------------------------------------------------
 

--- a/Jar File/How Create a Jar file
+++ b/Jar File/How Create a Jar file
@@ -8,6 +8,11 @@ And this will create a jar file inside target folder like target/configdemo-0.0.
 This is how we can run jar file
 java -jar  target/configdemo-0.0.1-SNAPSHOT.jar
 
+---------------------------------------------------------------------------------------------------------------
+
+This is how we can pass environment from JVM System Properties via running a jar file
+java -Dbuild.id=9999 -Dbuild.name=9Build -Dbuild.version=1.0.1 -jar target/configdemo-0.0.1-SNAPSHOT.jar
+
 -----------------------------------------------------------------------------------------
 
 This is the way how we can set any variable

--- a/configdemo/src/main/resources/application.yaml
+++ b/configdemo/src/main/resources/application.yaml
@@ -5,14 +5,15 @@ spring:
 #  profiles:
 #    active: dev
 
+# This is a default active profile
 build:
-##  This is the way to get dynamically id here, if we set ID=9999 like in intellij IDE
-  id: ${ID}
-#  id: 122
-  version: ${VERSION}
-#  version: 2.2.2
-  name: ${NAME}
-#  name: "Default-Build"
+##  This is the way to get dynamically id here if we set ID=9999 like in intellij IDE
+#  id: ${ID}
+  id: 122
+#  version: ${VERSION}
+  version: 2.2.2
+#  name: ${NAME}
+  name: "Default-Build"
 
 
 #  This is how we set environment variable from intellij IDE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on passing environment values to a jar at runtime via JVM system properties, with examples for build.id, build.name, and build.version.
* **Chores**
  * Updated default application configuration: added a default active profile note and set build id, version, and name to fixed defaults (122, 2.2.2, "Default-Build"), while keeping dynamic placeholders commented for reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->