### PR TITLE
accessing-configurations-from-a-private-server-config-repository-to-d…

### DIFF
--- a/configuration/spring-config-server/src/main/resources/application.yml
+++ b/configuration/spring-config-server/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
       server:
         git:
           uri: https://github.com/Aak172003/spring-app-configuration
+          # To access environments from private spring config server repository, we need to create a token for validation,
+          # or even we can do hard-coding as well
+          username: ${GIT_USER}
+          password: ${GIT_TOKEN}
 
 server:
   port: 8888


### PR DESCRIPTION
…o-this-create-fine-grained-token-via-goto-gitprofile-settings-inside-it-go-developer-settings-then-personal-access-token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Config Server now supports authenticated access to private Git repositories. Provide credentials via environment variables to securely fetch configuration from private sources, improving security and compatibility with restricted environments. Existing setups using public repositories continue to work without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->